### PR TITLE
Fix #1 Issue-1 npm Shrinkwrap not working in Mac

### DIFF
--- a/src/packageJsonProcessor.ts
+++ b/src/packageJsonProcessor.ts
@@ -13,15 +13,17 @@ export class PackageJsonProcessor{
         }
         try{
             let { stdout, stderr} = await exec("npm shrinkwrap",{cwd:workspaceRoot});
-			if (stdout) {
+            let npmShrinkWrapFile = "npm-shrinkwrap.json";
+            let shrinkWrapSucceeded = stdout || stderr.search(npmShrinkWrapFile)>-1
+			if (shrinkWrapSucceeded) {
 				let lines = stdout.split(/\r{0,1}\n/);
                 //read npm-shrinkwrap.json
-				let obj = JSON.parse(fs.readFileSync(path.join(workspaceRoot,"npm-shrinkwrap.json"), "utf8"));
+				let obj = JSON.parse(fs.readFileSync(path.join(workspaceRoot, npmShrinkWrapFile), "utf8"));
 				return this.flattenAndUniqDependencies(obj);
 			}
 		}
 		catch(e){
-            return Promise.reject('npm shrinkwrap failed, try running it manually to see what went wrong');
+            return Promise.reject('npm shrinkwrap failed, try running it manually to see what went wrong:' + e.error.message);
 		}
     }
 


### PR DESCRIPTION
Hi Juraj,
I was testing on my mac and the npm shrinkwrap command was returning messages to stderr and nothing to stdout. Anyway I added a handler for this to make it work on my mac. Could you review the PR and let me know if you are happy to merge. I do not have access to the repository.